### PR TITLE
Legg dele-cv-knappene under hverandre slik som i skissene

### DIFF
--- a/app/stilling/[stillingsId]/kandidatliste/_ui/KandidatVisningSidebar/KandidatHandlingerForStilling.tsx
+++ b/app/stilling/[stillingsId]/kandidatliste/_ui/KandidatVisningSidebar/KandidatHandlingerForStilling.tsx
@@ -98,7 +98,7 @@ const KandidatHandlingerForStilling: FC<KandidatHandlingerForStillingProps> = ({
         !fåttJobben &&
         !cvDeltMedArbeidsgiver &&
         !cvFjernetFraArbeidsgiver && (
-          <div className='grid grid-cols-2 gap-2'>
+          <div className='grid grid-rows-2 gap-2'>
             <DelMedKandidatModal
               markerteKandidater={[kandidat]}
               fjernAllMarkering={() => {}}


### PR DESCRIPTION
Legger del-cv-knappene under hverandre slik at de blir lik skissene og teksten ikke sklir utenfor knappen